### PR TITLE
Nonconventional Title Test!! feat(ci): have bors require conventional PR title before merging

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,8 +1,7 @@
 use_squash_merge = true
 cut_body_after = "_ _ _"
 pr_status = [
-# This must be un-commented once Bors merges the PR that new CI check
-#  "Validate conventional PR title",
+  "Validate conventional PR title",
 ]
 status = [
   "Check Rust formatting",


### PR DESCRIPTION
Follows up on #530, which needed to be merged first because the PR title check action needs to be merged before it will run.

Refs: #530